### PR TITLE
Allow connecting to ka-p.fontawesome.com in content security policy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -21,7 +21,7 @@
       script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://tagmanager.google.com use.typekit.net https://www.google-analytics.com https://kit.fontawesome.com https://js.hs-scripts.com https://js.hs-scripts.net https://js.hs-banner.com https://js.hs-analytics.net;
       style-src 'self' 'unsafe-inline' use.typekit.net p.typekit.net https://kit-pro.fontawesome.com https://tagmanager.google.com https://fonts.googleapis.com;
       img-src 'self' https://www.googletagmanager.com p.typekit.net https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com https://track.hubspot.com;
-      font-src 'self' data: use.typekit.net https://kit-pro.fontawesome.com https://fonts.gstatic.com;
+      font-src 'self' data: use.typekit.net https://ka-p.fontawesome.com https://kit-pro.fontawesome.com https://fonts.gstatic.com;
       """
     X-Frame-Options = "DENY"
     X-XSS-Protection = "1; mode=block"

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,7 +17,7 @@
   [headers.values]
     Content-Security-Policy = """
       default-src 'self';
-      connect-src 'self' https://www.google-analytics.com;
+      connect-src 'self' https://www.google-analytics.com https://ka-p.fontawesome.com;
       script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://tagmanager.google.com use.typekit.net https://www.google-analytics.com https://kit.fontawesome.com https://js.hs-scripts.com https://js.hs-scripts.net https://js.hs-banner.com https://js.hs-analytics.net;
       style-src 'self' 'unsafe-inline' use.typekit.net p.typekit.net https://kit-pro.fontawesome.com https://tagmanager.google.com https://fonts.googleapis.com;
       img-src 'self' https://www.googletagmanager.com p.typekit.net https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com https://track.hubspot.com;


### PR DESCRIPTION
## Overview

Allows loading CSS files from https://ka-p.fontawesome.com to fix outstanding CSP issues.

### Checklist

- [x] Deploy previews do not contain any content security policy errors

### Notes

I'm not sure this was directly related to https://github.com/FortAwesome/Font-Awesome/issues/17346. The content security policy would have prevented the request from going through in the first place, before it had a chance to hit a `403` on the Font Awesome side. We probably would have hit it if the requests had been going through though.

## Testing Instructions

* Go to the [deploy preview](https://deploy-preview-23--districtbuilder-marketing.netlify.app/).
* Confirm that there are no content security policy errors present in the console.

Closes #22 