### PR TITLE
Fix get-pip version, as done for many other projects

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,7 @@ Vagrant.configure("2") do |config|
     ansible.compatibility_mode = "2.0"
     ansible.install_mode = "pip_args_only"
     ansible.pip_args = "ansible==#{ANSIBLE_VERSION}"
+    ansible.pip_install_cmd = "curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | sudo python"
     ansible.playbook = "deployment/ansible/publicmapping.yml"
     ansible.galaxy_role_file = "deployment/ansible/roles.yml"
     ansible.galaxy_roles_path = "deployment/ansible/roles"

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,5 +1,8 @@
 ---
+pip_version: "20.2.*"
+pip_get_pip_version: "2.7"
 docker_version: "5:19.*"
 docker_compose_version: "1.25.*"
 docker_users:
   - "vagrant"
+nodejs_npm_version: "6.14.8"

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,5 +1,5 @@
 - src: azavea.pip
-  version: 2.0.0
+  version: 2.0.1
 
 - src: azavea.docker
   version: 5.0.0


### PR DESCRIPTION
## Overview

Fixes get-pip version.

## Testing Instructions

* Check out this branch and destroy your VM `vagrant destroy -f`
* Run the `setup` script
  - [ ] Ensure it succeeds